### PR TITLE
Allow using custom-dns on master-plane

### DIFF
--- a/modules/subnets/input.tf
+++ b/modules/subnets/input.tf
@@ -12,6 +12,10 @@ variable "on-premise-routes" {
   type = "list"
 }
 
+variable "link-local-dns" {
+  default = "169.254.169.254"
+}
+
 variable "search-domain" {}
 
 variable "custom-dns" {

--- a/modules/subnets/network_public.tf
+++ b/modules/subnets/network_public.tf
@@ -46,12 +46,13 @@ resource "oci_core_dhcp_options" "master" {
 
   options {
     type        = "DomainNameServer"
-    server_type = "VcnLocalPlusInternet"
+    server_type = "CustomDnsServer"
+    custom_dns_servers = ["${var.custom-dns}", "${var.link-local-dns}"]
   }
 
   options {
     type                = "SearchDomain"
-    search_domain_names = ["${var.vcn-dns-label}.oraclevcn.com"]
+    search_domain_names = ["${var.search-domain}"]
   }
 }
 


### PR DESCRIPTION
Master nodes use by default the Oracle Cloud DNS servers. In order to
have the access to a delegated zone we need to add the relevant DHCP 
options for custom DNS servers.